### PR TITLE
feat: add SQS tag propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CircleCI](https://circleci.com/gh/lumigo-io/SAR-Propagate-CFN-Tags.svg?style=svg)](https://circleci.com/gh/lumigo-io/SAR-Propagate-CFN-Tags)
 [![codecov](https://codecov.io/gh/lumigo-io/SAR-Propagate-CFN-Tags/branch/master/graph/badge.svg)](https://codecov.io/gh/lumigo-io/SAR-Propagate-CFN-Tags)
 
-SAR app to propagate CloudFormation's stack tags to resources that are currently not propagated automatically - e.g. CloudWatch Logs. It also propagates stack tag updates to resources whose tags are not automatically updated - e.g. Step Functions and IAM roles.
+SAR app to propagate CloudFormation's stack tags to resources that are currently not propagated automatically - e.g. CloudWatch Logs. It also propagates stack tag updates to resources whose tags are not automatically updated - e.g. Step Functions, SQS and IAM roles.
 
 ## Deploying to your account (via the console)
 

--- a/src/functions/lib/propagate-tags.js
+++ b/src/functions/lib/propagate-tags.js
@@ -5,7 +5,8 @@ const log = require("@dazn/lambda-powertools-logger");
 const Resources = [
 	require("./cloudwatch-logs"),
 	require("./step-functions"),
-	require("./iam-role")
+	require("./iam-role"),
+	require("./sqs"),
 ];
 
 const upsertTags = async (stackName, tags, physicalId, Resource) => {

--- a/src/functions/lib/sqs.js
+++ b/src/functions/lib/sqs.js
@@ -1,0 +1,30 @@
+process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = "1";
+const AWS = require("aws-sdk");
+const SQS = new AWS.SQS();
+const log = require("@dazn/lambda-powertools-logger");
+
+const resourceType = "AWS::SQS::Queue";
+
+const upsertTags = async (QueueUrl, toUpsert) => {
+	const tagNames = Object.keys(toUpsert);
+	if (tagNames.length > 0) {
+		log.info("upserting tags...", {
+			QueueUrl,
+			count: tagNames.length,
+			tags: tagNames.join(",")
+		});
+
+		const Tags = tagNames.map(key => ({
+			key: key,
+			value: toUpsert[key]
+		}));
+		await SQS
+			.tagQueue({ QueueUrl, Tags })
+			.promise();
+	}
+};
+
+module.exports = {
+	resourceType,
+	upsertTags
+};

--- a/src/functions/lib/sqs.test.js
+++ b/src/functions/lib/sqs.test.js
@@ -1,0 +1,44 @@
+const AWS = require("aws-sdk");
+
+const mockTagResource = jest.fn();
+AWS.SQS.prototype.tagQueue = mockTagResource;
+
+console.log = jest.fn();
+
+beforeEach(() => {
+	mockTagResource.mockReturnValue({
+		promise: () => Promise.resolve()
+	});
+});
+
+afterEach(() => {
+	mockTagResource.mockReset();
+});
+
+describe("sqs queue", () => {
+	const queueUrl = "https://sqs.eu-central-1.amazonaws.com/123456789/my-fancy-queue";
+
+	describe("upsert-tags", () => {
+		const stackTags = {
+			team: "atlantis",
+			feature: "content-item"
+		};
+		const stackTagsKV = [{
+			key: "team",
+			value: "atlantis"
+		}, {
+			key: "feature",
+			value: "content-item"
+		}];
+
+		test("tagResource is called with new tags", async () => {
+			const SQSqueues = require("./sqs");
+
+			await SQSqueues.upsertTags(queueUrl, stackTags);
+			expect(mockTagResource).toBeCalledWith({
+				QueueUrl: queueUrl,
+				Tags: stackTagsKV
+			});
+		});
+	});
+});


### PR DESCRIPTION
* SQS is another resource where tags aren't added or updated by CloudFormation updates
* This change introduces SQS tag propagation