### PR TITLE
fix(sqs): update tags format

### DIFF
--- a/src/functions/lib/sqs.js
+++ b/src/functions/lib/sqs.js
@@ -5,8 +5,8 @@ const log = require("@dazn/lambda-powertools-logger");
 
 const resourceType = "AWS::SQS::Queue";
 
-const upsertTags = async (QueueUrl, toUpsert) => {
-	const tagNames = Object.keys(toUpsert);
+const upsertTags = async (QueueUrl, Tags) => {
+	const tagNames = Object.keys(Tags);
 	if (tagNames.length > 0) {
 		log.info("upserting tags...", {
 			QueueUrl,
@@ -14,10 +14,6 @@ const upsertTags = async (QueueUrl, toUpsert) => {
 			tags: tagNames.join(",")
 		});
 
-		const Tags = tagNames.map(key => ({
-			key: key,
-			value: toUpsert[key]
-		}));
 		await SQS
 			.tagQueue({ QueueUrl, Tags })
 			.promise();

--- a/src/functions/lib/sqs.test.js
+++ b/src/functions/lib/sqs.test.js
@@ -23,13 +23,10 @@ describe("sqs queue", () => {
 			team: "atlantis",
 			feature: "content-item"
 		};
-		const stackTagsKV = [{
-			key: "team",
-			value: "atlantis"
-		}, {
-			key: "feature",
-			value: "content-item"
-		}];
+		const stackTagsKV = {
+			team: "atlantis" ,
+			feature: "content-item"
+		};
 
 		test("tagResource is called with new tags", async () => {
 			const SQSqueues = require("./sqs");


### PR DESCRIPTION
The `Tags` format for the sdk call is different to what was merged in #10:

https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#tagQueue-property
```
Tags — (map<String>)
The list of tags to be added to the specified queue.
```

This change updates the format of `Tags` to a map of strings.