### PR TITLE
Add missing SQS policy and clean up the policies

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -34,15 +34,10 @@ Resources:
             Action:
               - cloudformation:DescribeStacks
               - cloudformation:DescribeStackResources
-              - logs:ListTagsLogGroup
               - logs:TagLogGroup
-              - logs:UntagLogGroup
-              - states:ListTagsForResource
               - states:TagResource
-              - states:UntagResource
-              - iam:ListRoleTags
               - iam:TagRole
-              - iam:UntagRole
+              - sqs:TagQueue
             Resource: "*"
       Events:
         CloudFormationEvent:
@@ -59,6 +54,7 @@ Resources:
                 eventName:
                   - CreateStack
                   - UpdateStack
+                  - ExecuteChangeSet
 
   PropagateLogGroup:
     Type: AWS::Logs::LogGroup
@@ -77,15 +73,10 @@ Resources:
               - cloudformation:ListStacks
               - cloudformation:DescribeStacks
               - cloudformation:DescribeStackResources
-              - logs:ListTagsLogGroup
               - logs:TagLogGroup
-              - logs:UntagLogGroup
-              - states:ListTagsForResource
               - states:TagResource
-              - states:UntagResource
-              - iam:ListRoleTags
               - iam:TagRole
-              - iam:UntagRole
+              - sqs:TagQueue
             Resource: "*"
 
   PropagateAllLogGroup:


### PR DESCRIPTION
Remove ListTags and Untag policies are not used by the lambdas at all.
Add missing TagQueue policy for SQS.
Add ExecuteChangeSet event for invoking Propagate function because when you are creating or updating the stack using SAM or dotnet cli, the CreateStack or UpdateStack event is not raised.