### PR TITLE
Bump lambda-invocation-cfn-custom-resource version from 1.4.0 to 1.5.0

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -87,7 +87,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:374852340823:applications/lambda-invocation-cfn-custom-resource
-        SemanticVersion: 1.4.0
+        SemanticVersion: 1.5.0
 
   # custom resource to invoke the PropagateAll function during deployment
   InvokePropagateAll:


### PR DESCRIPTION
Seeing problems deploying due to node.js version in 1.4.0, AWS has deprecated nodejs10.x.

Bumping to 1.5.0 brings in nodejs14.x