### PR TITLE
feat: stop propagateTags when no staskName is in the event

### DIFF
--- a/src/functions/propagate.js
+++ b/src/functions/propagate.js
@@ -6,5 +6,9 @@ module.exports.handler = async (event) => {
 	log.debug("received event...", { event });
   
 	const stackName = _.get(event, "detail.requestParameters.stackName");
-	await propagateTags(stackName);
+	if (stackName) {
+		await propagateTags(stackName);
+	} else {
+		log.warn("event has no stackName, skipped...");
+	}
 };

--- a/src/functions/propagate.test.js
+++ b/src/functions/propagate.test.js
@@ -24,6 +24,14 @@ describe("propagate handler", () => {
 			}
 		}
 	});
+
+	const getEventWithNoStackName = (eventName = "CreateStack") => ({
+		detail: {
+			eventName,
+			requestParameters: {
+			}
+		}
+	});
   
 	test("nothing is done if stack is not found", async () => {
 		givenStackIsNotFound();
@@ -105,6 +113,18 @@ describe("propagate handler", () => {
     
 		expect(mockTagLogGroup).toBeCalledTimes(1);
 	});
+
+	test("propagateTags is not called if stackName is not found in the event", async () => {
+		jest.resetModules();
+		const propagateTags = require("./lib/propagate-tags");
+		const mockPropagateTags = jest.fn();
+		propagateTags.propagateTags = mockPropagateTags;
+		const handler = require("./propagate").handler;
+		await handler(getEventWithNoStackName());
+
+		expect(mockPropagateTags).not.toBeCalled();
+	});
+
 });
 
 function givenStackHasTags(tags) {


### PR DESCRIPTION
Stop processing stack when the event doesn't have a value in detail.requestParameters.stackName

**What is this PR about?**

- Stop propagate tags when an event received doesn't have a value for `detail.requestParameters.stackName`

**Why?**

- We see many UpdateStack events with no value set for stackName.
- For these kinds of events, propagateTags will not be able to do anything. So Instead of making a `DescribeStasks` call with no target stack name this change will skip the process of these events. 
- DescribeStacks with no target stack name require extra IAM action `ListStacks`, see AWS docs on [Request Parameters - StackName](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeStacks.html#API_DescribeStacks_RequestParameters)  


**An example of events with no stackName:**

![image](https://user-images.githubusercontent.com/4750140/228887684-ace156b2-7561-418b-a95c-fa0e43a55af2.png)


